### PR TITLE
Added support for 'py' as the code block type

### DIFF
--- a/coglint/coglint.py
+++ b/coglint/coglint.py
@@ -75,7 +75,7 @@ class CogLint(Cog):
 
         for c in code_blocks:
             is_python, code = c.split(None, 1)
-            is_python = is_python.lower() == "python"
+            is_python = is_python.lower() in ["python", "py"]
             if is_python:  # Then we're in business
                 linted, errors = await self.lint_code(code)
                 linted = linted.getvalue()


### PR DESCRIPTION
People (me included) often use the shorter version of defining python usage within a code block on discord: `py`. This small change should add support for it, since the following is also considered a Python code in Discord:

\```py
print("Hello world!")
\```

Note: Noticed while checking out the code and wanted to help by improving it, **didn't test this change** but it should work.