### PR TITLE
Use relative imports in cogs

### DIFF
--- a/chatter/chat.py
+++ b/chatter/chat.py
@@ -7,10 +7,10 @@ from redbot.core import Config
 from redbot.core import commands
 from redbot.core.data_manager import cog_data_path
 
-from chatter.chatterbot import ChatBot
-from chatter.chatterbot.comparisons import levenshtein_distance
-from chatter.chatterbot.response_selection import get_first_response
-from chatter.chatterbot.trainers import ListTrainer
+from .chatterbot import ChatBot
+from .chatterbot.comparisons import levenshtein_distance
+from .chatterbot.response_selection import get_first_response
+from .chatterbot.trainers import ListTrainer
 from typing import Any
 
 Cog: Any = getattr(commands, "Cog", object)

--- a/chatter/chatterbot/chatterbot.py
+++ b/chatter/chatterbot/chatterbot.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 
 import logging
 
-from chatter.chatterbot import utils
+from . import utils
 
 
 class ChatBot(object):
@@ -11,7 +11,7 @@ class ChatBot(object):
     """
 
     def __init__(self, name, **kwargs):
-        from chatter.chatterbot.logic import MultiLogicAdapter
+        from .logic import MultiLogicAdapter
 
         self.name = name
         kwargs['name'] = name
@@ -136,7 +136,7 @@ class ChatBot(object):
         """
         Learn that the statement provided is a valid response.
         """
-        from chatter.chatterbot.conversation import Response
+        from .conversation import Response
 
         if previous_statement:
             statement.add_response(

--- a/chatter/chatterbot/comparisons.py
+++ b/chatter/chatterbot/comparisons.py
@@ -92,7 +92,7 @@ class SynsetDistance(Comparator):
         """
         Download required NLTK corpora if they have not already been downloaded.
         """
-        from chatter.chatterbot.utils import nltk_download_corpus
+        from .utils import nltk_download_corpus
 
         nltk_download_corpus('corpora/wordnet')
 
@@ -100,7 +100,7 @@ class SynsetDistance(Comparator):
         """
         Download required NLTK corpora if they have not already been downloaded.
         """
-        from chatter.chatterbot.utils import nltk_download_corpus
+        from .utils import nltk_download_corpus
 
         nltk_download_corpus('tokenizers/punkt')
 
@@ -108,7 +108,7 @@ class SynsetDistance(Comparator):
         """
         Download required NLTK corpora if they have not already been downloaded.
         """
-        from chatter.chatterbot.utils import nltk_download_corpus
+        from .utils import nltk_download_corpus
 
         nltk_download_corpus('corpora/stopwords')
 
@@ -124,7 +124,7 @@ class SynsetDistance(Comparator):
         """
         from nltk.corpus import wordnet
         from nltk import word_tokenize
-        from chatter.chatterbot import utils
+        from . import utils
         import itertools
 
         tokens1 = word_tokenize(statement.text.lower())
@@ -177,7 +177,7 @@ class SentimentComparison(Comparator):
         Download the NLTK vader lexicon for sentiment analysis
         that is required for this algorithm to run.
         """
-        from chatter.chatterbot.utils import nltk_download_corpus
+        from .utils import nltk_download_corpus
 
         nltk_download_corpus('sentiment/vader_lexicon')
 
@@ -252,7 +252,7 @@ class JaccardSimilarity(Comparator):
         Download the NLTK wordnet corpora that is required for this algorithm
         to run only if the corpora has not already been downloaded.
         """
-        from chatter.chatterbot.utils import nltk_download_corpus
+        from .utils import nltk_download_corpus
 
         nltk_download_corpus('corpora/wordnet')
 

--- a/chatter/chatterbot/ext/sqlalchemy_app/models.py
+++ b/chatter/chatterbot/ext/sqlalchemy_app/models.py
@@ -3,9 +3,9 @@ from sqlalchemy.ext.declarative import declared_attr, declarative_base
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 
-from chatter.chatterbot.constants import TAG_NAME_MAX_LENGTH, STATEMENT_TEXT_MAX_LENGTH
-from chatter.chatterbot.conversation import StatementMixin
-from chatter.chatterbot.ext.sqlalchemy_app.types import UnicodeString
+from ...constants import TAG_NAME_MAX_LENGTH, STATEMENT_TEXT_MAX_LENGTH
+from ...conversation import StatementMixin
+from .types import UnicodeString
 
 
 class ModelBase(object):
@@ -72,8 +72,8 @@ class Statement(Base, StatementMixin):
         return [tag.name for tag in self.tags]
 
     def get_statement(self):
-        from chatter.chatterbot.conversation import Statement as StatementObject
-        from chatter.chatterbot.conversation import Response as ResponseObject
+        from ...conversation import Statement as StatementObject
+        from ...conversation import Response as ResponseObject
 
         statement = StatementObject(
             self.text,

--- a/chatter/chatterbot/input/gitter.py
+++ b/chatter/chatterbot/input/gitter.py
@@ -2,8 +2,8 @@ from __future__ import unicode_literals
 
 from time import sleep
 
-from chatter.chatterbot.conversation import Statement
-from chatter.chatterbot.input import InputAdapter
+from ..conversation import Statement
+from . import InputAdapter
 
 
 class Gitter(InputAdapter):

--- a/chatter/chatterbot/input/hipchat.py
+++ b/chatter/chatterbot/input/hipchat.py
@@ -2,8 +2,8 @@ from __future__ import unicode_literals
 
 from time import sleep
 
-from chatter.chatterbot.conversation import Statement
-from chatter.chatterbot.input import InputAdapter
+from ..conversation import Statement
+from . import InputAdapter
 
 
 class HipChat(InputAdapter):

--- a/chatter/chatterbot/input/input_adapter.py
+++ b/chatter/chatterbot/input/input_adapter.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 
-from chatter.chatterbot.adapters import Adapter
+from ..adapters import Adapter
 
 
 class InputAdapter(Adapter):

--- a/chatter/chatterbot/input/mailgun.py
+++ b/chatter/chatterbot/input/mailgun.py
@@ -2,8 +2,8 @@ from __future__ import unicode_literals
 
 import datetime
 
-from chatter.chatterbot.conversation import Statement
-from chatter.chatterbot.input import InputAdapter
+from ..conversation import Statement
+from . import InputAdapter
 
 
 class Mailgun(InputAdapter):

--- a/chatter/chatterbot/input/microsoft.py
+++ b/chatter/chatterbot/input/microsoft.py
@@ -2,8 +2,8 @@ from __future__ import unicode_literals
 
 from time import sleep
 
-from chatter.chatterbot.conversation import Statement
-from chatter.chatterbot.input import InputAdapter
+from ..conversation import Statement
+from . import InputAdapter
 
 
 class Microsoft(InputAdapter):

--- a/chatter/chatterbot/input/terminal.py
+++ b/chatter/chatterbot/input/terminal.py
@@ -1,8 +1,8 @@
 from __future__ import unicode_literals
 
-from chatter.chatterbot.conversation import Statement
-from chatter.chatterbot.input import InputAdapter
-from chatter.chatterbot.utils import input_function
+from ..conversation import Statement
+from . import InputAdapter
+from ..utils import input_function
 
 
 class TerminalAdapter(InputAdapter):

--- a/chatter/chatterbot/input/variable_input_type_adapter.py
+++ b/chatter/chatterbot/input/variable_input_type_adapter.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 
-from chatter.chatterbot.conversation import Statement
-from chatter.chatterbot.input import InputAdapter
+from ..conversation import Statement
+from . import InputAdapter
 
 
 class VariableInputTypeAdapter(InputAdapter):

--- a/chatter/chatterbot/logic/best_match.py
+++ b/chatter/chatterbot/logic/best_match.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 
-from chatter.chatterbot.logic import LogicAdapter
+from . import LogicAdapter
 
 
 class BestMatch(LogicAdapter):

--- a/chatter/chatterbot/logic/logic_adapter.py
+++ b/chatter/chatterbot/logic/logic_adapter.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 
-from chatter.chatterbot.adapters import Adapter
-from chatter.chatterbot.utils import import_module
+from ..adapters import Adapter
+from ..utils import import_module
 
 
 class LogicAdapter(Adapter):
@@ -18,8 +18,8 @@ class LogicAdapter(Adapter):
 
     def __init__(self, **kwargs):
         super(LogicAdapter, self).__init__(**kwargs)
-        from chatter.chatterbot.comparisons import levenshtein_distance
-        from chatter.chatterbot.response_selection import get_first_response
+        from ..comparisons import levenshtein_distance
+        from ..response_selection import get_first_response
 
         # Import string module parameters
         if 'statement_comparison_function' in kwargs:

--- a/chatter/chatterbot/logic/low_confidence.py
+++ b/chatter/chatterbot/logic/low_confidence.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 
-from chatter.chatterbot.conversation import Statement
-from chatter.chatterbot.logic import BestMatch
+from ..conversation import Statement
+from . import BestMatch
 
 
 class LowConfidenceAdapter(BestMatch):

--- a/chatter/chatterbot/logic/mathematical_evaluation.py
+++ b/chatter/chatterbot/logic/mathematical_evaluation.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 
-from chatter.chatterbot.conversation import Statement
-from chatter.chatterbot.logic import LogicAdapter
+from ..conversation import Statement
+from . import LogicAdapter
 
 
 class MathematicalEvaluation(LogicAdapter):

--- a/chatter/chatterbot/logic/multi_adapter.py
+++ b/chatter/chatterbot/logic/multi_adapter.py
@@ -2,8 +2,8 @@ from __future__ import unicode_literals
 
 from collections import Counter
 
-from chatter.chatterbot import utils
-from chatter.chatterbot.logic import LogicAdapter
+from .. import utils
+from . import LogicAdapter
 
 
 class MultiLogicAdapter(LogicAdapter):

--- a/chatter/chatterbot/logic/no_knowledge_adapter.py
+++ b/chatter/chatterbot/logic/no_knowledge_adapter.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 
-from chatter.chatterbot.logic import LogicAdapter
+from . import LogicAdapter
 
 
 class NoKnowledgeAdapter(LogicAdapter):

--- a/chatter/chatterbot/logic/specific_response.py
+++ b/chatter/chatterbot/logic/specific_response.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 
-from chatter.chatterbot.logic import LogicAdapter
+from . import LogicAdapter
 
 
 class SpecificResponseAdapter(LogicAdapter):
@@ -16,7 +16,7 @@ class SpecificResponseAdapter(LogicAdapter):
 
     def __init__(self, **kwargs):
         super(SpecificResponseAdapter, self).__init__(**kwargs)
-        from chatter.chatterbot.conversation import Statement
+        from ..conversation import Statement
 
         self.input_text = kwargs.get('input_text')
 

--- a/chatter/chatterbot/logic/time_adapter.py
+++ b/chatter/chatterbot/logic/time_adapter.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 
 from datetime import datetime
 
-from chatter.chatterbot.logic import LogicAdapter
+from . import LogicAdapter
 
 
 class TimeLogicAdapter(LogicAdapter):
@@ -81,7 +81,7 @@ class TimeLogicAdapter(LogicAdapter):
         return features
 
     def process(self, statement):
-        from chatter.chatterbot.conversation import Statement
+        from ..conversation import Statement
 
         now = datetime.now()
 

--- a/chatter/chatterbot/output/gitter.py
+++ b/chatter/chatterbot/output/gitter.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 
-from chatter.chatterbot.output import OutputAdapter
+from . import OutputAdapter
 
 
 class Gitter(OutputAdapter):

--- a/chatter/chatterbot/output/hipchat.py
+++ b/chatter/chatterbot/output/hipchat.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 
 import json
 
-from chatter.chatterbot.output import OutputAdapter
+from . import OutputAdapter
 
 
 class HipChat(OutputAdapter):

--- a/chatter/chatterbot/output/mailgun.py
+++ b/chatter/chatterbot/output/mailgun.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 
-from chatter.chatterbot.output import OutputAdapter
+from . import OutputAdapter
 
 
 class Mailgun(OutputAdapter):

--- a/chatter/chatterbot/output/microsoft.py
+++ b/chatter/chatterbot/output/microsoft.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 
 import json
 
-from chatter.chatterbot.output import OutputAdapter
+from . import OutputAdapter
 
 
 class Microsoft(OutputAdapter):

--- a/chatter/chatterbot/output/output_adapter.py
+++ b/chatter/chatterbot/output/output_adapter.py
@@ -1,4 +1,4 @@
-from chatter.chatterbot.adapters import Adapter
+from ..adapters import Adapter
 
 
 class OutputAdapter(Adapter):

--- a/chatter/chatterbot/output/terminal.py
+++ b/chatter/chatterbot/output/terminal.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 
-from chatter.chatterbot.output import OutputAdapter
+from . import OutputAdapter
 
 
 class TerminalAdapter(OutputAdapter):

--- a/chatter/chatterbot/storage/mongodb.py
+++ b/chatter/chatterbot/storage/mongodb.py
@@ -1,4 +1,4 @@
-from chatter.chatterbot.storage import StorageAdapter
+from . import StorageAdapter
 
 
 class Query(object):
@@ -119,7 +119,7 @@ class MongoDatabaseAdapter(StorageAdapter):
         """
         Return the class for the statement model.
         """
-        from chatter.chatterbot.conversation import Statement
+        from ..conversation import Statement
 
         # Create a storage-aware statement
         statement = Statement
@@ -131,7 +131,7 @@ class MongoDatabaseAdapter(StorageAdapter):
         """
         Return the class for the response model.
         """
-        from chatter.chatterbot.conversation import Response
+        from ..conversation import Response
 
         # Create a storage-aware response
         response = Response

--- a/chatter/chatterbot/storage/sql_storage.py
+++ b/chatter/chatterbot/storage/sql_storage.py
@@ -1,8 +1,8 @@
-from chatter.chatterbot.storage import StorageAdapter
+from . import StorageAdapter
 
 
 def get_response_table(response):
-    from chatter.chatterbot.ext.sqlalchemy_app.models import Response
+    from ..ext.sqlalchemy_app.models import Response
     return Response(text=response.text, occurrence=response.occurrence)
 
 
@@ -86,28 +86,28 @@ class SQLStorageAdapter(StorageAdapter):
         """
         Return the statement model.
         """
-        from chatter.chatterbot.ext.sqlalchemy_app.models import Statement
+        from ..ext.sqlalchemy_app.models import Statement
         return Statement
 
     def get_response_model(self):
         """
         Return the response model.
         """
-        from chatter.chatterbot.ext.sqlalchemy_app.models import Response
+        from ..ext.sqlalchemy_app.models import Response
         return Response
 
     def get_conversation_model(self):
         """
         Return the conversation model.
         """
-        from chatter.chatterbot.ext.sqlalchemy_app.models import Conversation
+        from ..ext.sqlalchemy_app.models import Conversation
         return Conversation
 
     def get_tag_model(self):
         """
         Return the conversation model.
         """
-        from chatter.chatterbot.ext.sqlalchemy_app.models import Tag
+        from ..ext.sqlalchemy_app.models import Tag
         return Tag
 
     def count(self):
@@ -379,14 +379,14 @@ class SQLStorageAdapter(StorageAdapter):
         """
         Drop the database attached to a given adapter.
         """
-        from chatter.chatterbot.ext.sqlalchemy_app.models import Base
+        from ..ext.sqlalchemy_app.models import Base
         Base.metadata.drop_all(self.engine)
 
     def create(self):
         """
         Populate the database with the tables.
         """
-        from chatter.chatterbot.ext.sqlalchemy_app.models import Base
+        from ..ext.sqlalchemy_app.models import Base
         Base.metadata.create_all(self.engine)
 
     def _session_finish(self, session, statement_text=None):

--- a/chatter/chatterbot/trainers.py
+++ b/chatter/chatterbot/trainers.py
@@ -2,8 +2,8 @@ import logging
 import os
 import sys
 
-from chatter.chatterbot import utils
-from chatter.chatterbot.conversation import Statement, Response
+from . import utils
+from .conversation import Statement, Response
 
 
 class Trainer(object):
@@ -127,7 +127,7 @@ class ChatterBotCorpusTrainer(Trainer):
 
     def __init__(self, storage, **kwargs):
         super(ChatterBotCorpusTrainer, self).__init__(storage, **kwargs)
-        from chatter.chatterbot.corpus import Corpus
+        from .corpus import Corpus
 
         self.corpus = Corpus()
 

--- a/chatter/chatterbot/utils.py
+++ b/chatter/chatterbot/utils.py
@@ -11,8 +11,16 @@ def import_module(dotted_path):
     import importlib
 
     module_parts = dotted_path.split('.')
+    if module_parts[:2] == ["chatter", "chatterbot"]:
+        # An import path starting with chatter.chatterbot means it comes from this
+        # package, and should be imported relatively.
+        package = __package__
+        module_parts = module_parts[2:]
+        module_parts[0] = "." + module_parts[0]
+    else:
+        package = None
     module_path = '.'.join(module_parts[:-1])
-    module = importlib.import_module(module_path)
+    module = importlib.import_module(module_path, package=package)
 
     return getattr(module, module_parts[-1])
 
@@ -46,7 +54,7 @@ def validate_adapter_class(validate_class, adapter_class):
 
     :raises: Adapter.InvalidAdapterTypeException
     """
-    from chatter.chatterbot.adapters import Adapter
+    from .adapters import Adapter
 
     # If a dictionary was passed in, check if it has an import_path attribute
     if isinstance(validate_class, dict):
@@ -128,7 +136,7 @@ def remove_stopwords(tokens, language):
     Stop words are words like "is, the, a, ..."
 
     Be sure to download the required NLTK corpus before calling this function:
-    - from chatter.chatterbot.utils import nltk_download_corpus
+    - from chatterbot.utils import nltk_download_corpus
     - nltk_download_corpus('corpora/stopwords')
     """
     from nltk.corpus import stopwords

--- a/werewolf/builder.py
+++ b/werewolf/builder.py
@@ -8,9 +8,9 @@ import discord
 # Import all roles here
 from redbot.core import commands
 
-from werewolf.roles.seer import Seer
-from werewolf.roles.vanillawerewolf import VanillaWerewolf
-from werewolf.roles.villager import Villager
+from .roles.seer import Seer
+from .roles.vanillawerewolf import VanillaWerewolf
+from .roles.villager import Villager
 from redbot.core.utils.menus import menu, prev_page, next_page, close_menu
 
 # All roles in this list for iterating

--- a/werewolf/game.py
+++ b/werewolf/game.py
@@ -5,10 +5,10 @@ from typing import List, Any, Dict, Set, Union
 import discord
 from redbot.core import commands
 
-from werewolf.builder import parse_code
-from werewolf.player import Player
-from werewolf.role import Role
-from werewolf.votegroup import VoteGroup
+from .builder import parse_code
+from .player import Player
+from .role import Role
+from .votegroup import VoteGroup
 
 
 class Game:

--- a/werewolf/night_powers.py
+++ b/werewolf/night_powers.py
@@ -1,4 +1,4 @@
-from werewolf.role import Role
+from .role import Role
 
 
 def night_immune(role: Role):

--- a/werewolf/roles/seer.py
+++ b/werewolf/roles/seer.py
@@ -1,5 +1,5 @@
-from werewolf.night_powers import pick_target
-from werewolf.role import Role
+from ..night_powers import pick_target
+from ..role import Role
 
 
 class Seer(Role):

--- a/werewolf/roles/shifter.py
+++ b/werewolf/roles/shifter.py
@@ -1,5 +1,5 @@
-from werewolf.night_powers import pick_target
-from werewolf.role import Role
+from ..night_powers import pick_target
+from ..role import Role
 
 
 class Shifter(Role):

--- a/werewolf/roles/vanillawerewolf.py
+++ b/werewolf/roles/vanillawerewolf.py
@@ -1,6 +1,6 @@
-from werewolf.role import Role
+from ..role import Role
 
-from werewolf.votegroups.wolfvote import WolfVote
+from ..votegroups.wolfvote import WolfVote
 
 
 class VanillaWerewolf(Role):

--- a/werewolf/roles/villager.py
+++ b/werewolf/roles/villager.py
@@ -1,4 +1,4 @@
-from werewolf.role import Role
+from ..role import Role
 
 
 class Villager(Role):

--- a/werewolf/votegroups/wolfvote.py
+++ b/werewolf/votegroups/wolfvote.py
@@ -1,6 +1,6 @@
 import random
 
-from werewolf.votegroup import VoteGroup
+from ..votegroup import VoteGroup
 
 
 class WolfVote(VoteGroup):

--- a/werewolf/werewolf.py
+++ b/werewolf/werewolf.py
@@ -5,8 +5,8 @@ from redbot.core import Config, checks
 from redbot.core.bot import Red
 from redbot.core import commands
 
-from werewolf.builder import GameBuilder, role_from_name, role_from_alignment, role_from_category, role_from_id
-from werewolf.game import Game
+from .builder import GameBuilder, role_from_name, role_from_alignment, role_from_category, role_from_id
+from .game import Game
 from redbot.core.utils.menus import menu, DEFAULT_CONTROLS
 from typing import Any
 


### PR DESCRIPTION
A future update to Red will mean doing an absolute import starting with your cog package's name will be unsupported. It wasn't really intended to work in the first place :grimacing:.

I had to do this carefully in chatter, as migrating to relative imports was a little tricker than usual there. I think I got it right though. See changes to `utils.import_module`.

The change which will break absolute imports is in Cog-Creators/Red-DiscordBot#2446. It's an unintended side effect, but I don't see a reason to support them going forward if we can help people migrate away from using them :smiley:.