### PR TITLE
[lovecalculator] fixed problem being unable to get results

### DIFF
--- a/lovecalculator/lovecalculator.py
+++ b/lovecalculator/lovecalculator.py
@@ -30,7 +30,7 @@ class LoveCalculator(Cog):
                 soup_object = BeautifulSoup(await response.text(), "html.parser")
                 try:
                     description = (
-                        soup_object.find("div", attrs={"class": "result score"}).get_text().strip()
+                        soup_object.find("div", attrs={"class": "result__score"}).get_text().strip()
                     )
                 except:
                     description = "Dr. Love is busy right now"


### PR DESCRIPTION
I tried using lovecalculator on my server and kept getting the "Dr. Love is busy" note, so I compared the code with the actual html source for the webpage being queried and found that the python code tried to query "result score" but the html source outputs "result__score" so I tried changing it in the code and it started giving proper results.