### PR TITLE
Fixes an error in [p]qrinvite when image_url is not passed

### DIFF
--- a/qrinvite/qrinvite.py
+++ b/qrinvite/qrinvite.py
@@ -50,7 +50,7 @@ class QRInvite(Cog):
             invite = invite.code
 
         if image_url is None:
-            image_url = ctx.guild.icon_url
+            image_url = str(ctx.guild.icon_url)
 
         if image_url == "":  # Still
             await ctx.send(


### PR DESCRIPTION
If the param `image_url` isn't passed, it defaults to `ctx.guild.icon_url` which returns an `Asset obj` (I believe this changed in ~dpy1.2.3) instead of a `str`. This PR wraps `ctx.guild.icon_url` in `str()` so the `pathlib.Path` later does not throw an error.

This fixes #68