### PR TITLE
[ForceMention] Disable role mention auto-sanitizer when sending pinging message

### DIFF
--- a/forcemention/forcemention.py
+++ b/forcemention/forcemention.py
@@ -9,7 +9,7 @@ import asyncio
 
 Cog: Any = getattr(commands, "Cog", object)
 
-if version_info < VersionInfo.from_str("3.3.2"):
+if version_info < VersionInfo.from_str("3.4.0"):
     SANITIZE_ROLES_KWARG = {}
 else:
     SANITIZE_ROLES_KWARG = {"sanitize_roles": False}

--- a/forcemention/forcemention.py
+++ b/forcemention/forcemention.py
@@ -1,5 +1,6 @@
 from discord.utils import get
 
+from redbot import VersionInfo, version_info
 from redbot.core import Config, checks, commands
 
 from redbot.core.bot import Red
@@ -8,6 +9,10 @@ import asyncio
 
 Cog: Any = getattr(commands, "Cog", object)
 
+if version_info < VersionInfo.from_str("3.3.2"):
+    SANITIZE_ROLES_KWARG = {}
+else:
+    SANITIZE_ROLES_KWARG = {"sanitize_roles": False}
 
 class ForceMention(Cog):
     """
@@ -36,8 +41,8 @@ class ForceMention(Cog):
 
         if not role_obj.mentionable:
             await role_obj.edit(mentionable=True)
-            await ctx.send("{}\n{}".format(role_obj.mention, message))
+            await ctx.send("{}\n{}".format(role_obj.mention, message), **SANITIZE_ROLES_KWARG)
             await asyncio.sleep(5)
             await role_obj.edit(mentionable=False)
         else:
-            await ctx.send("{}\n{}".format(role_obj.mention, message))
+            await ctx.send("{}\n{}".format(role_obj.mention, message), **SANITIZE_ROLES_KWARG)


### PR DESCRIPTION
Starting with Red 3.4.0, `ctx.send` will automatically sanitize role mentions in message's content to avoid mass-mentioning people by accident. This behavior can be disabled with `sanitize_roles` kwarg set to `False`.
This PR adds that kwarg to `ctx.send` call when Red version is higher than or equal to 3.4.0.
This version hasn't been released just yet, but the change was already merged in develop version which means it's a matter of max few days before the 3.4.0 release happens so you might be interested in having the fix ready in time and this PR keeps the backwards-compatibility so you don't have to worry about merging it before the release.
