### PR TITLE
[ForceMention] Remove incorrect 3.4+ compatibility layer

### DIFF
--- a/forcemention/forcemention.py
+++ b/forcemention/forcemention.py
@@ -1,15 +1,9 @@
 import asyncio
 
 from discord.utils import get
-from redbot import VersionInfo, version_info
 from redbot.core import Config, checks, commands
 from redbot.core.bot import Red
 from redbot.core.commands import Cog
-
-if version_info < VersionInfo.from_str("3.4.0"):
-    SANITIZE_ROLES_KWARG = {}
-else:
-    SANITIZE_ROLES_KWARG = {"sanitize_roles": False}
 
 
 class ForceMention(Cog):
@@ -39,8 +33,8 @@ class ForceMention(Cog):
 
         if not role_obj.mentionable:
             await role_obj.edit(mentionable=True)
-            await ctx.send("{}\n{}".format(role_obj.mention, message), **SANITIZE_ROLES_KWARG)
+            await ctx.send("{}\n{}".format(role_obj.mention, message))
             await asyncio.sleep(5)
             await role_obj.edit(mentionable=False)
         else:
-            await ctx.send("{}\n{}".format(role_obj.mention, message), **SANITIZE_ROLES_KWARG)
+            await ctx.send("{}\n{}".format(role_obj.mention, message))


### PR DESCRIPTION
The 3.4.0 compatibility layer that I have contributed in the past is no longer correct. `sanitize_roles` kwarg is no longer planned as discord gave us native way to specify allowed mentions. I simply removed the compatibility layer, as I'm not sure how you will want to handle - you *could* for example just drop pre-3.4 support (when 3.4 gets released that is) and use the cool allowed_mentions feature along with Mention Everyone perm on the bot which now allows the bot to ping any role or maybe you will want to use separate logics for pre-3.4 and post-3.4 or *maybe* you will do something else ¯\_(ツ)_/¯