### PR TITLE
Timerole develop

### DIFF
--- a/timerole/timerole.py
+++ b/timerole/timerole.py
@@ -64,11 +64,12 @@ class Timerole(Cog):
 
         Useful for troubleshooting the initial setup
         """
-        pre_run = datetime.utcnow()
         async with ctx.typing():
+            pre_run = datetime.utcnow()
             await self.timerole_update()
+            after_run = datetime.utcnow()
             await ctx.tick()
-        after_run = datetime.utcnow()
+
         await ctx.maybe_send_embed(f"Took {after_run-pre_run} seconds")
 
     @commands.group()
@@ -187,7 +188,7 @@ class Timerole(Cog):
 
         # all_mrs = await self.config.custom("RoleMember").all()
 
-        log.debug(f"Begin timerole update")
+        # log.debug(f"Begin timerole update")
 
         for guild in self.bot.guilds:
             guild_id = guild.id

--- a/timerole/timerole.py
+++ b/timerole/timerole.py
@@ -27,10 +27,15 @@ class Timerole(Cog):
         self.bot = bot
         self.config = Config.get_conf(self, identifier=9811198108111121, force_registration=True)
         default_global = {}
-        default_guild = {"announce": None, "roles": {}}
+        default_guild = {"announce": None}
+        default_memberrole = {"had_role": False, "check_again_time": None}
 
         self.config.register_global(**default_global)
         self.config.register_guild(**default_guild)
+
+        self.config.init_custom("MemberRole", 2)
+        self.config.register_custom("MemberRole", **default_memberrole)
+
         self.updating = asyncio.create_task(self.check_hour())
 
     async def red_delete_data_for_user(self, **kwargs):


### PR DESCRIPTION
Adds the "reapply" option in the settings, per guild.

When disabled, roles will not be added if it sees the user had the role before, and roles will not be removed if it sees the user didn't have the role before.

This handles the logic differently than before for all configured roles, so it reapply is "True" by default to behave as before.

Resolves #128 