### PR TITLE
[StealEmoji] update to use guild.emoji_limit

### DIFF
--- a/stealemoji/stealemoji.py
+++ b/stealemoji/stealemoji.py
@@ -16,16 +16,16 @@ log = logging.getLogger("red.fox_v3.stealemoji")
 
 
 async def check_guild(guild, emoji):
-    if len(guild.emojis) >= 100:
+    if len(guild.emojis) >= 2*guild.emoji_limit:
         return False
 
     if len(guild.emojis) < 50:
         return True
 
     if emoji.animated:
-        return sum(e.animated for e in guild.emojis) < 50
+        return sum(e.animated for e in guild.emojis) < guild.emoji_limit
     else:
-        return sum(not e.animated for e in guild.emojis) < 50
+        return sum(not e.animated for e in guild.emojis) < guild.emoji_limit
 
 
 class StealEmoji(Cog):

--- a/stealemoji/stealemoji.py
+++ b/stealemoji/stealemoji.py
@@ -16,7 +16,7 @@ log = logging.getLogger("red.fox_v3.stealemoji")
 
 
 async def check_guild(guild, emoji):
-    if len(guild.emojis) >= 2*guild.emoji_limit:
+    if len(guild.emojis) >= 2 * guild.emoji_limit:
         return False
 
     if len(guild.emojis) < 50:

--- a/stealemoji/stealemoji.py
+++ b/stealemoji/stealemoji.py
@@ -19,7 +19,7 @@ async def check_guild(guild, emoji):
     if len(guild.emojis) >= 2 * guild.emoji_limit:
         return False
 
-    if len(guild.emojis) < 50:
+    if len(guild.emojis) < guild.emoji_limit:
         return True
 
     if emoji.animated:


### PR DESCRIPTION
Previously, StealEmoji only allowed up to 50 animated/unanimated emojis each, regardless of server boost status. This PR updates the logic to incorporate `guild.emoji_limit` instead.