### PR TITLE
[Chatter] Allow bot to reply to maintain conversation continuity and will respond to reply

### DIFF
--- a/chatter/chat.py
+++ b/chatter/chat.py
@@ -500,7 +500,15 @@ class Chatter(Cog):
         # Thank you Cog-Creators
         channel: discord.TextChannel = message.channel
 
-        if guild is not None and channel.id == await self.config.guild(guild).chatchannel():
+        # is_reply = False # this is only useful with in_response_to
+        if (
+            message.reference is not None
+            and isinstance(message.reference.resolved,discord.Message)
+            and message.reference.resolved.author.id == self.bot.user.id
+        ):
+            # is_reply = True # this is only useful with in_response_to
+            pass  # this is a reply to the bot, good to go
+        elif guild is not None and channel.id == await self.config.guild(guild).chatchannel():
             pass  # good to go
         else:
             when_mentionables = commands.when_mentioned(self.bot, message)

--- a/chatter/chat.py
+++ b/chatter/chat.py
@@ -53,7 +53,13 @@ class Chatter(Cog):
         self.bot = bot
         self.config = Config.get_conf(self, identifier=6710497116116101114)
         default_global = {}
-        default_guild = {"whitelist": None, "days": 1, "convo_delta": 15, "chatchannel": None}
+        default_guild = {
+            "whitelist": None,
+            "days": 1,
+            "convo_delta": 15,
+            "chatchannel": None,
+            "reply": False,
+        }
         path: pathlib.Path = cog_data_path(self)
         self.data_path = path / "database.sqlite3"
 
@@ -212,6 +218,25 @@ class Chatter(Cog):
                 return
             await self.config.guild(ctx.guild).chatchannel.set(channel.id)
             await ctx.maybe_send_embed(f"Chat channel is now {channel.mention}")
+
+    @checks.admin()
+    @chatter.command(name="reply")
+    async def chatter_reply(self, ctx: commands.Context, toggle: Optional[bool] = None):
+        """
+        Toggle bot reply to messages if conversation continuity is not present
+
+        """
+        reply = await self.config.guild(ctx.guild).reply()
+        if toggle is None:
+            toggle = not reply
+        await self.config.guild(ctx.guild).reply.set(toggle)
+
+        if toggle:
+            await ctx.send("I will now respond to you if conversation continuity is not present")
+        else:
+            await ctx.send(
+                "I will not reply to your message if conversation continuity is not present, anymore"
+            )
 
     @checks.is_owner()
     @chatter.command(name="cleardata")
@@ -493,7 +518,12 @@ class Chatter(Cog):
         async with channel.typing():
             future = await self.loop.run_in_executor(None, self.chatbot.get_response, text)
 
+            replying = None
+            if await self.config.guild(guild).reply():
+                if message != ctx.channel.last_message:
+                    replying = message
+
             if future and str(future):
-                await channel.send(str(future))
+                await channel.send(str(future), reference=replying)
             else:
                 await channel.send(":thinking:")

--- a/chatter/chat.py
+++ b/chatter/chat.py
@@ -58,7 +58,7 @@ class Chatter(Cog):
             "days": 1,
             "convo_delta": 15,
             "chatchannel": None,
-            "reply": False,
+            "reply": True,
         }
         path: pathlib.Path = cog_data_path(self)
         self.data_path = path / "database.sqlite3"

--- a/chatter/chat.py
+++ b/chatter/chat.py
@@ -503,7 +503,7 @@ class Chatter(Cog):
         # is_reply = False # this is only useful with in_response_to
         if (
             message.reference is not None
-            and isinstance(message.reference.resolved,discord.Message)
+            and isinstance(message.reference.resolved, discord.Message)
             and message.reference.resolved.author.id == self.bot.user.id
         ):
             # is_reply = True # this is only useful with in_response_to

--- a/chatter/info.json
+++ b/chatter/info.json
@@ -2,7 +2,7 @@
   "author": [
     "Bobloy"
   ],
-  "min_bot_version": "3.4.0",
+  "min_bot_version": "3.4.6",
   "description": "Create an offline chatbot that talks like your average member using Machine Learning. See setup instructions at https://github.com/bobloy/Fox-V3/tree/master/chatter",
   "hidden": false,
   "install_msg": "Thank you for installing Chatter! Please make sure you check the install instructions at https://github.com/bobloy/Fox-V3/blob/master/chatter/README.md\nAfter that, get started ith `[p]load chatter` and `[p]help Chatter`",

--- a/launchlib/launchlib.py
+++ b/launchlib/launchlib.py
@@ -152,7 +152,9 @@ class LaunchLib(commands.Cog):
 
             if pad_name is not None:
                 if location_url is not None:
-                    location_url = re.sub("[^a-zA-Z0-9/:.'+\"°?=,-]", "", location_url)  # Fix bad URLS
+                    location_url = re.sub(
+                        "[^a-zA-Z0-9/:.'+\"°?=,-]", "", location_url
+                    )  # Fix bad URLS
                     em.add_field(name="Launch Pad Name", value=f"[{pad_name}]({location_url})")
                 else:
                     em.add_field(name="Launch Pad Name", value=pad_name)


### PR DESCRIPTION
if enabled in the guild with `chatter reply`, the bot will reply to message to maintain "conversation continuity"
i'm not really sure if that the best way to phrase it, also help message could be better if you have any idea to make it clearer
exemple:
![image](https://user-images.githubusercontent.com/15911822/111007607-86334100-838f-11eb-8df5-95f383d8fa6b.png)
I disabled it by default but since it's a cool feature maybe it should be enabled by default.
This line is really edge case prone but i don't think there is any way to make it better
`if message != ctx.channel.last_message:`
one edge case is if last message of the channel gets deleted just before bot's message gets sent, d.py cache doesn't get updated in time and it can make it ugly (see bellow) but there isn't really a way to solve that
![image](https://user-images.githubusercontent.com/15911822/111008207-da8af080-8390-11eb-9e5f-60370f13ef28.png)
Per d.py's doc, last_message is optional so maybe it could be an edge case but i'm probably going too far with that

To note, chatter's min_bot_version is bumped to [red's version which updated d.py to v1.6](https://docs.discord.red/en/stable/changelog_3_4_0.html#id2) (reply support)

Edit:
Also made the bot respond to reply to him