### PR TITLE
[SCP] Remove double setup

### DIFF
--- a/scp/scp.py
+++ b/scp/scp.py
@@ -177,7 +177,3 @@ class SCP(Cog):
 
         msg = "http://www.scp-wiki.net/log-of-unexplained-locations"
         await ctx.maybe_send_embed(msg)
-
-
-def setup(bot):
-    bot.add_cog(SCP(bot))


### PR DESCRIPTION
Noticed that the setup in the main file wasn't being used inside ``__init__.py``, instead the function was re-created. Nothing breaking just a quick "fix".