### PR TITLE
[LoveCalculator] Patch AttributeError

### DIFF
--- a/lovecalculator/lovecalculator.py
+++ b/lovecalculator/lovecalculator.py
@@ -49,7 +49,11 @@ class LoveCalculator(Cog):
 
         result_image = soup_object.find("img", class_="result__image").get("src")
 
-        result_text = soup_object.find("div", class_="result-text").get_text()
+        result_text = soup_object.find("div", class_="result-text")
+        if result_text is None:
+            result_text = f"{x} and {y} aren't compatible 😔"
+        else:
+            result_text.get_text()
         result_text = " ".join(result_text.split())
 
         try:


### PR DESCRIPTION
Adds a user friendly flavor text when result text causes an attribute error.
Relevant traceback:
```
Traceback (most recent call last):
  File "/home/phen/noumenon-core/.venv/lib/python3.8/site-packages/discord/ext/commands/core.py", line 85, in wrapped
    ret = await coro(*args, **kwargs)
  File "/home/phen/noumenon/cogs/CogManager/cogs/lovecalculator/lovecalculator.py", line 43, in lovecalculator
    description = soup_object.find("div", class_="result__score").get_text()
AttributeError: 'NoneType' object has no attribute 'get_text'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/phen/noumenon-core/.venv/lib/python3.8/site-packages/discord/ext/commands/bot.py", line 939, in invoke
    await ctx.command.invoke(ctx)
  File "/home/phen/noumenon-core/.venv/lib/python3.8/site-packages/discord/ext/commands/core.py", line 863, in invoke
    await injected(*ctx.args, **ctx.kwargs)
  File "/home/phen/noumenon-core/.venv/lib/python3.8/site-packages/discord/ext/commands/core.py", line 94, in wrapped
    raise CommandInvokeError(exc) from exc
discord.ext.commands.errors.CommandInvokeError: Command raised an exception: AttributeError: 'NoneType' object has no attribute 'get_text'
```