### PR TITLE
Fix error on `[p]lovecalculator` command

### DIFF
--- a/lovecalculator/lovecalculator.py
+++ b/lovecalculator/lovecalculator.py
@@ -53,7 +53,7 @@ class LoveCalculator(Cog):
         if result_text is None:
             result_text = f"{x} and {y} aren't compatible 😔"
         else:
-            result_text.get_text()
+            result_text = result_text.get_text()
         result_text = " ".join(result_text.split())
 
         try:


### PR DESCRIPTION
For context, this was the previous error
```
Traceback (most recent call last):
  File "/home/main/redenv/lib/python3.8/site-packages/discord/ext/commands/core.py", line 85, in wrapped
    ret = await coro(*args, **kwargs)
  File "/home/main/red/cogs/CogManager/cogs/lovecalculator/lovecalculator.py", line 57, in lovecalculator
    result_text = " ".join(result_text.split())
TypeError: 'NoneType' object is not callable

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/main/redenv/lib/python3.8/site-packages/discord/ext/commands/bot.py", line 939, in invoke
    await ctx.command.invoke(ctx)
  File "/home/main/redenv/lib/python3.8/site-packages/discord/ext/commands/core.py", line 863, in invoke
    await injected(*ctx.args, **ctx.kwargs)
  File "/home/main/redenv/lib/python3.8/site-packages/discord/ext/commands/core.py", line 94, in wrapped
    raise CommandInvokeError(exc) from exc
discord.ext.commands.errors.CommandInvokeError: Command raised an exception: TypeError: 'NoneType' object is not callable
```