### PR TITLE
additional exit conditions to recyclingplant

### DIFF
--- a/recyclingplant/recyclingplant.py
+++ b/recyclingplant/recyclingplant.py
@@ -32,6 +32,7 @@ class RecyclingPlant(Cog):
 
         x = 0
         reward = 0
+        timeoutcount = 0
         await ctx.send(
             "{0} has signed up for a shift at the Recycling Plant! Type ``exit`` to terminate it early.".format(
                 ctx.author.display_name
@@ -53,7 +54,7 @@ class RecyclingPlant(Cog):
                 return m.author == ctx.author and m.channel == ctx.channel
 
             try:
-                answer = await self.bot.wait_for("message", timeout=120, check=check)
+                answer = await self.bot.wait_for("message", timeout=20, check=check)
             except asyncio.TimeoutError:
                 answer = None
 

--- a/recyclingplant/recyclingplant.py
+++ b/recyclingplant/recyclingplant.py
@@ -61,11 +61,17 @@ class RecyclingPlant(Cog):
             if answer is None:
                 if timeoutcount == 2:
                     await ctx.send(
-                        "{} slacked off at work, so they were sacked with no pay.".format(ctx.author.display_name)
+                        "{} slacked off at work, so they were sacked with no pay.".format(
+                            ctx.author.display_name
                         )
+                    )
                     break
                 else:
-                    await ctx.send("{} is slacking, and if they carry on not working, they'll be fired.".format(ctx.author.display_name))
+                    await ctx.send(
+                        "{} is slacking, and if they carry on not working, they'll be fired.".format(
+                            ctx.author.display_name
+                        )
+                    )
                     timeoutcount += 1
             elif answer.content.lower().strip() == used["action"]:
                 await ctx.send(

--- a/recyclingplant/recyclingplant.py
+++ b/recyclingplant/recyclingplant.py
@@ -59,9 +59,14 @@ class RecyclingPlant(Cog):
                 answer = None
 
             if answer is None:
-                await ctx.send(
-                    "``{}`` fell down the conveyor belt to be sorted again!".format(used["object"])
-                )
+                if timeoutcount == 2:
+                    await ctx.send(
+                        "{} slacked off at work, so they were sacked with no pay.".format(ctx.author.display_name)
+                        )
+                    break
+                else:
+                    await ctx.send("{} is slacking, and if they carry on not working, they'll be fired.".format(ctx.author.display_name))
+                    timeoutcount += 1
             elif answer.content.lower().strip() == used["action"]:
                 await ctx.send(
                     "Congratulations! You put ``{}`` down the correct chute! (**+50**)".format(


### PR DESCRIPTION
#192 
If a user runs [p]recyclingplant and then does not respond, the bot will continuously spam the channel until the user runs exit or until they finish the 'work'. Even bot owners cannot stop the cycle, unloading and loading the cog does not break the loop, so a bot restart is required to break out of this.

This adds an exit condition if they don't respond to 3 prompts. 