### PR TITLE
Switch from git:// to https://

### DIFF
--- a/chatter/chat.py
+++ b/chatter/chat.py
@@ -400,7 +400,7 @@ class Chatter(Cog):
             pred = MessagePredicate.yes_or_no(ctx)
             try:
                 await self.bot.wait_for("message", check=pred, timeout=30)
-            except TimeoutError:
+            except asyncio.TimeoutError:
                 await ctx.send("Response timed out, please try again later.")
                 return
             if not pred.result:

--- a/chatter/info.json
+++ b/chatter/info.json
@@ -7,7 +7,7 @@
   "hidden": false,
   "install_msg": "Thank you for installing Chatter! Please make sure you check the install instructions at https://github.com/bobloy/Fox-V3/blob/master/chatter/README.md\nAfter that, get started ith `[p]load chatter` and `[p]help Chatter`",
   "requirements": [
-    "git+git://github.com/bobloy/ChatterBot@fox#egg=ChatterBot>=1.1.0.dev4",
+    "git+https://github.com/bobloy/ChatterBot@fox#egg=ChatterBot>=1.1.0.dev4",
     "kaggle",
     "https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.1.0/en_core_web_sm-3.1.0.tar.gz#egg=en_core_web_sm",
     "https://github.com/explosion/spacy-models/releases/download/en_core_web_md-3.1.0/en_core_web_md-3.1.0.tar.gz#egg=en_core_web_md"


### PR DESCRIPTION
Fix an install error, as GitHub has dropped support for insecure git:// clones.