### PR TITLE
Increase max SCP article number

### DIFF
--- a/scp/scp.py
+++ b/scp/scp.py
@@ -25,11 +25,11 @@ class SCP(Cog):
 
         # Thanks Shigbeard and Redjumpman for helping me!
 
-        if 0 < num <= 5999:
+        if 0 < num <= 9999:
             msg = "http://www.scp-wiki.net/scp-{:03}".format(num)
             c = discord.Color.green()
         else:
-            msg = "You must specify a number between 1 and 5999."
+            msg = "You must specify a number between 1 and 9999."
             c = discord.Color.red()
 
         if await ctx.embed_requested():


### PR DESCRIPTION
The number of SCP articles is now beyond 5999 and up to 9999. This is a placeholder and in general a bit more work can go into this add-on later.