### PR TITLE
Support both red 3.4 and 3.5 in fifo and firstmessage cogs

### DIFF
--- a/fifo/__init__.py
+++ b/fifo/__init__.py
@@ -13,7 +13,7 @@ sys.modules["CustomDateTrigger"] = CustomDateTrigger
 
 async def setup(bot):
     cog = FIFO(bot)
-    bot.add_cog(cog)
+    await bot.add_cog(cog)
     await cog.initialize()
 
 

--- a/fifo/__init__.py
+++ b/fifo/__init__.py
@@ -13,7 +13,9 @@ sys.modules["CustomDateTrigger"] = CustomDateTrigger
 
 async def setup(bot):
     cog = FIFO(bot)
-    await bot.add_cog(cog)
+    r = bot.add_cog(cog)
+    if r is not None:
+        await r
     await cog.initialize()
 
 

--- a/fifo/task.py
+++ b/fifo/task.py
@@ -121,6 +121,7 @@ class FakeMessage(discord.Message):
         self,
         author: discord.Member,
         channel: discord.TextChannel,
+        guild: discord.Guild,
         content,
     ):
         # self.content = content
@@ -134,7 +135,7 @@ class FakeMessage(discord.Message):
         self.author = author
         # self._handle_author(author._user._to_minimal_user_json())
         # self._handle_member(author)
-        self._rebind_channel_reference(channel)
+        self._rebind_cached_references(guild, channel)
         self._update(
             {
                 "content": content,
@@ -412,7 +413,7 @@ class Task:
 
         message = FakeMessage(message=actual_message)
         message = neuter_message(message)
-        message.process_the_rest(author=author, channel=channel, content=new_content)
+        message.process_the_rest(author=author, channel=channel, guild=guild, content=new_content)
 
         if (
             not message.guild

--- a/firstmessage/__init__.py
+++ b/firstmessage/__init__.py
@@ -2,4 +2,4 @@ from .firstmessage import FirstMessage
 
 
 async def setup(bot):
-    bot.add_cog(FirstMessage(bot))
+    await bot.add_cog(FirstMessage(bot))

--- a/firstmessage/__init__.py
+++ b/firstmessage/__init__.py
@@ -2,4 +2,7 @@ from .firstmessage import FirstMessage
 
 
 async def setup(bot):
-    await bot.add_cog(FirstMessage(bot))
+    cog = FirstMessage(bot)
+    r = bot.add_cog(cog)
+    if r is not None:
+        await r

--- a/firstmessage/firstmessage.py
+++ b/firstmessage/firstmessage.py
@@ -35,15 +35,16 @@ class FirstMessage(commands.Cog):
         if channel is None:
             channel = ctx.channel
         try:
-            message: discord.Message = (
-                await channel.history(limit=1, oldest_first=True).flatten()
-            )[0]
+            message: discord.Message = next(
+                iter([message async for message in channel.history(limit=1, oldest_first=True)]),
+                None,
+            )
         except (discord.Forbidden, discord.HTTPException):
             log.exception(f"Unable to read message history for {channel.id=}")
             await ctx.maybe_send_embed("Unable to read message history for that channel")
             return
 
         em = discord.Embed(description=f"[First Message in {channel.mention}]({message.jump_url})")
-        em.set_author(name=message.author.display_name, icon_url=message.author.avatar_url)
+        em.set_author(name=message.author.display_name, icon_url=message.author.avatar.url)
 
         await ctx.send(embed=em)


### PR DESCRIPTION
The fifo and firstmessage cogs are supported under both red 3.4 and red 3.5 by:

- in the cog load for both cogs, await the cog_add, but only if needed (i.e. only if red 3.5)
- in FakeMessage (fifo), signature match the right internals to call in order to synthesize the message