### PR TITLE
Update __init__.py

### DIFF
--- a/fifo/__init__.py
+++ b/fifo/__init__.py
@@ -13,7 +13,7 @@ sys.modules["CustomDateTrigger"] = CustomDateTrigger
 
 async def setup(bot):
     cog = FIFO(bot)
-    bot.add_cog(cog)
+    await bot.add_cog(cog)
     await cog.initialize()
 
 


### PR DESCRIPTION
to fix "RuntimeWarning: coroutine 'Red.add_cog' was never awaited
  bot.add_cog(cog)" using redbot 3.5.2